### PR TITLE
Fix ROSA version regex

### DIFF
--- a/roles/install_cloud_clis/tasks/rosa_cli.yml
+++ b/roles/install_cloud_clis/tasks/rosa_cli.yml
@@ -15,7 +15,7 @@
 
     - name: Determine installed ROSA CLI version
       ansible.builtin.set_fact:
-        installed_rosa_cli_ver: "{{ rosa_ver_installed_result.stdout | regex_replace('(?s)^(?P<version>\\d{1,2}\\.\\d{1,2}\\.\\d{1,3}).*$', '\\g<version>', multiline=True) }}"
+        installed_rosa_cli_ver: "{{ rosa_ver_installed_result.stdout_lines | first | regex_replace('(?s)^INFO: (?P<version>\\d{1,2}\\.\\d{1,2}\\.\\d{1,3}).*$', '\\g<version>') }}"
 
     - name: Determine if there is a newer version
       ansible.builtin.set_fact:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

Fixes regex used to determine installed `rosa` version.

<!-- Brief explanation of the code or documentation change you've made -->

### How should this be tested?

<!-- Automated tests are preferred, but not always doable - especially for infrastructure.
Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

1. Install an older version of the `rosa`  cli (1.2.41 is what was used for this testing).
2. Run the `cloud_cli_update.yml` playbook and check the version reported in the upgraded message at the end of the play

### Is there a relevant Issue open for this?

<!-- Provide a link to any open issues that describe the problem you are solving. -->
<!-- resolves #[number] ->>
No

### Other Relevant info, PRs, etc

<!-- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
